### PR TITLE
Allow to read-out huge memory allocations.

### DIFF
--- a/inc/Hardware/Print.hpp
+++ b/inc/Hardware/Print.hpp
@@ -25,7 +25,7 @@ namespace Hardware
 		* @brief Prints the current memory consumption. 
 		* @author Nicolai Müller
 		*/		
-        unsigned int MemoryConsumption();
+        uint64_t MemoryConsumption();
 		
 		/**
 		* @brief Prints the command line parameters. 

--- a/src/Hardware/Print.cpp
+++ b/src/Hardware/Print.cpp
@@ -507,16 +507,17 @@ unsigned int Hardware::Print::EvaluationSettings(Hardware::SimulationStruct& Sim
     return Maximum;
 }
 
-unsigned int Hardware::Print::MemoryConsumption(){
+uint64_t Hardware::Print::MemoryConsumption(){
     std::ifstream Status("/proc/self/status");
     std::string Line, Number;
-    unsigned int ram = 0;
+    uint64_t ram = 0;
 
     if (Status.is_open()){
         while (getline(Status,Line)){
+            // Parse VmSize: 21475178120 kB
             if (Line.find("VmSize") != std::string::npos){
                 Number = Line.substr(7, Line.length());
-                ram = std::stoi(Number.substr(0, Number.length() - 2));
+                ram = std::stoll(Number.substr(0, Number.length() - 2));
                 break;
             }
         }


### PR DESCRIPTION
When running the example in the top directory PROLEAD is crashing by throwing a std::out_of_range. While clearly something is wrong with the amount of allocated data (21475178120 kB on my WSL2 based system) it can be prevented from crashing by reading out the allocated memory in an unsigned 64 bits value.

**Error**:
```
Evaluate security under the robust probing model!
----------------------------------------------------------------------------------------------------------------------------------------
|      Elapsed Time |      Required Ram |  Processed Simulations | Probing Set with highest Information Leakage |  -log10(p) |  Status |
----------------------------------------------------------------------------------------------------------------------------------------
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoi
```
**Backtrace**:
```
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007ffff6bbb3b6 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007ffff6ba187c in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007ffff6f8aee6 in __gnu_cxx::__verbose_terminate_handler () at ../../../../src/libstdc++-v3/libsupc++/vterminate.cc:95
#6  0x00007ffff6f9ce9c in __cxxabiv1::__terminate (handler=<optimized out>) at ../../../../src/libstdc++-v3/libsupc++/eh_terminate.cc:48
#7  0x00007ffff6f9cf07 in std::terminate () at ../../../../src/libstdc++-v3/libsupc++/eh_terminate.cc:58
#8  0x00007ffff6f9d168 in __cxxabiv1::__cxa_throw (obj=<optimized out>, tinfo=0x7ffff7143168 <typeinfo for std::out_of_range>, dest=0x7ffff6fb4410 <std::out_of_range::~out_of_range()>)
    at ../../../../src/libstdc++-v3/libsupc++/eh_throw.cc:98
#9  0x00007ffff6f8e27c in std::__throw_out_of_range (__s=__s@entry=0x5555558d5c80 "stoi") at ../../../../../src/libstdc++-v3/src/c++11/functexcept.cc:86
#10 0x0000555555864e31 in __gnu_cxx::__stoa<long, int, char, int> (__idx=0x0, __str=0x7ffff5053180 "\t21475178120 ", __name=0x5555558d5c80 "stoi", __convf=<optimized out>)
    at /usr/include/c++/12/ext/string_conversions.h:86
#11 std::__cxx11::stoi (__base=10, __idx=0x0, __str="\t21475178120 ") at /usr/include/c++/12/bits/basic_string.h:3980
#12 Hardware::Print::MemoryConsumption () at src/Hardware/Print.cpp:519
#13 0x0000555555866bf9 in Hardware::Print::EvaluationResults (Settings=..., Simulation=..., Test=..., DeletedAlpha=@0x7ffff51e90d0: 0, DeletedProbingSet="",
    ElapsedTimePeriod=<optimized out>, Space=Space@entry=47) at src/Hardware/Print.cpp:585
#14 0x0000555555844aba in Hardware::Analyze::RobustProbingSecurityForSomeProbingSets (Library=..., Circuit=..., Settings=..., SharedData=SharedData@entry=0x6060000047c0, Simulation=...,
    Test=..., StartTime=..., ProbeStepIndex=<optimized out>) at src/Hardware/Analyze.cpp:154
#15 0x00005555558516f1 in Hardware::Analyze::UnivariateRobustProbingSecurity (Library=..., Circuit=..., Settings=..., SharedData=<optimized out>, Simulation=..., Test=..., StartTime=...)
    at src/Hardware/Analyze.cpp:115
#16 0x0000555555852a49 in Hardware::Analyze::RobustProbingSecurity (Library=..., Circuit=..., Settings=..., SharedData=SharedData@entry=0x6060000047c0, Simulation=..., Test=...)
    at src/Hardware/Analyze.cpp:28
```

